### PR TITLE
bug de tamanho dos contatos resolvido

### DIFF
--- a/style/contatos.css
+++ b/style/contatos.css
@@ -1,5 +1,6 @@
 .contatos{
     height: 50vh;
+    min-height: 500px;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
Bug resolvido;
Tamanho minimo da seção contatos em telas menores ficava com seu conteudo vazando para fora da seção. resolvido adcionando uma "min-height: 500px" onde limita o tamanho minimo da altura da seção.